### PR TITLE
Restyled the logo sizes according to sponsor reqs

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,21 +148,25 @@
       <div class="container mt-4">
         <div class="sponsor-section">
           <h3 class="mb-3 lead"><strong>Our Sponsors</strong></h3>
-          <div class="d-flex justify-content-center align-items-center flex-wrap">
-            <div class="sponsor-logo">
-              <a href="https://www.ubisoft.com/">
-                <img id="ubisoft" src="./assets/sponsor_graphics/Ubisoft_logo.svg" alt="Ubisoft" height="150">
-              </a>
+          <div class="sponsor-logos">
+            <div class="sponsor-row">
+              <div class="sponsor-logo">
+                <a href="https://www.ubisoft.com/">
+                  <img id="ubisoft" src="./assets/sponsor_graphics/Ubisoft_logo.svg" alt="Ubisoft" height="200">
+                </a>
+              </div>
             </div>
-            <div class="sponsor-logo">
-              <a href="https://www.accenture.com/">
-                <img id="accenture" src="./assets/sponsor_graphics/Accenture_logo.svg" alt="Accenture" height="70">
-              </a>
-            </div>
-            <div class="sponsor-logo">
-              <a href="https://www.tresor.gouv.qc.ca/">
-                <img id="conseil" src="./assets/sponsor_graphics/Conseil_au_Tresor_logo.svg" alt="Secrétariat du Conseil au trésor" height="80">
-              </a>
+            <div class="sponsor-row">
+              <div class="sponsor-logo">
+                <a href="https://www.accenture.com/">
+                  <img id="accenture" src="./assets/sponsor_graphics/Accenture_logo.svg" alt="Accenture" height="70">
+                </a>
+              </div>
+              <div class="sponsor-logo">
+                <a href="https://www.tresor.gouv.qc.ca/">
+                  <img id="conseil" src="./assets/sponsor_graphics/Conseil_au_Tresor_logo.svg" alt="Secrétariat du Conseil au trésor" height="80">
+                </a>
+              </div>
             </div>
           </div>
         </div>

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -9,6 +9,7 @@
 }
 
 #Sponsors h3 {
+    font-weight: bold;
     text-align: center;
   }
 
@@ -17,27 +18,58 @@
     padding: 20px;
   }
 
+.sponsor-logos {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+.sponsor-row {
+   display: flex;
+   justify-content: center;
+   align-items: center;
+   margin: 25px;
+  }
+
 .sponsor-logo {
-    margin: 50px;
+    margin: 40px;
   }
 
 @media (max-width: 1000px) {
     #ubisoft {
-      height: 100px;
+      height: 120px;
     }
 
     #accenture {
-      max-height: 50px;
+      max-height: 40px;
     }
 
     #conseil {
-      max-height: 60px;
+      max-height: 50px;
     }
-    
+
     .sponsor-logo {
         margin: 20px;
       }
   }
+
+  @media (max-width: 400px) {
+    #ubisoft {
+      height: 80px;
+    }
+
+    #accenture {
+      max-height: 25px;
+    }
+
+    #conseil {
+      max-height: 30px;
+    }
+      .sponsor-logo {
+          margin: 10px;
+        }
+    }
 
 footer {
   background-color: #e0cbef;


### PR DESCRIPTION
- resized ubisoft to "large", others to "medium"
- verified the quebec logo matches given guidelines

testing this just involves going on this branch, opening the home page and going to sponsor section. Feel free to resize the page, it should be responsive enough all the way down to around 250px in width